### PR TITLE
feat: allow different target builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,21 @@
 FROM alpine:3.13
 
 ARG KUBECTL_VERSION="1.21.2"
+ARG TARGETARCH
 
 RUN apk add py-pip curl wget ca-certificates git bash jq gcc alpine-sdk
 RUN pip install 'awscli==1.22.26'
-RUN curl -L -o /usr/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/kubectl
+RUN set -x echo ${TARGETARCH}
+RUN curl -L -o /usr/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/${TARGETARCH}/kubectl
 RUN chmod +x /usr/bin/kubectl
 
-RUN curl -o /usr/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator
+RUN curl -o /usr/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/${TARGETARCH}/aws-iam-authenticator
 RUN chmod +x /usr/bin/aws-iam-authenticator
 
-RUN wget https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm
+RUN wget https://get.helm.sh/helm-v3.8.0-linux-${TARGETARCH}.tar.gz -O - | tar -xzO linux-${TARGETARCH}/helm > /usr/local/bin/helm
 RUN chmod +x /usr/local/bin/helm
 
-RUN wget "https://github.com/weaveworks/eksctl/releases/download/v0.147.0/eksctl_$(uname -s)_amd64.tar.gz" -O - | tar -xz -C /usr/local/bin
+RUN wget "https://github.com/weaveworks/eksctl/releases/download/v0.147.0/eksctl_$(uname -s)_${TARGETARCH}.tar.gz" -O - | tar -xz -C /usr/local/bin
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
           aws-region: us-east-1
 
       - name: helm deploy
-        uses: tensor-hq/eksctl-helm-action@master
+        uses: tensor-hq/eksctl-helm-action@main
         with:
           eks_cluster: my-prod-cluster
           plugins: "https://github.com/jkroepke/helm-secrets" # optional

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   eks_cluster:
     description: "Name of your EKS cluster (i.e., from `eksctl get cluster`)"
     required: true
+  verbose:
+    description: "Enables shell command tracing. Takes string input 'true' or 'false'. Defaults to false."
+    required: true
+    default: "false"
 outputs:
   result:
     description: "Output returned by your Helm or kubectl command"

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ inputs:
     required: true
   image:
     description: "Optionally use a pre-built image to save build time"
-    required: true
+    required: false
     default: "Dockerfile"
   verbose:
     description: "Enables shell command tracing. Takes string input 'true' or 'false'. Defaults to false."
-    required: true
+    required: false
     default: "false"
 outputs:
   result:

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   eks_cluster:
     description: "Name of your EKS cluster (i.e., from `eksctl get cluster`)"
     required: true
+  image:
+    description: "Optionally use a pre-built image to save build time"
+    required: true
+    default: "Dockerfile"
   verbose:
     description: "Enables shell command tracing. Takes string input 'true' or 'false'. Defaults to false."
     required: true
@@ -22,6 +26,6 @@ outputs:
     description: "Output returned by your Helm or kubectl command"
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: ${{ input.image }}
   args:
     - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-set -xe
+set -e
+
+if [[ "${INPUT_VERBOSE}" == "true" ]]; then
+    set -x
+fi
 
 export KUBECONFIG="${PWD}/kubeconfig"
 eksctl utils write-kubeconfig --cluster $INPUT_EKS_CLUSTER --kubeconfig $KUBECONFIG
@@ -19,6 +23,6 @@ fi
 
 echo "running entrypoint command(s)"
 
-response=$(sh -xc "$INPUT_COMMAND")
+response=$(sh -c "$INPUT_COMMAND")
 
 echo "::set-output name=response::$response"


### PR DESCRIPTION
This allows to build native images for target platforms. Fixes issues with arm runners trying to run this action.

Additionally:
- adds option for using pre-built image (would save about 1 min from each build)
- adds toggle for the verbose debug logging

fixes https://github.com/tensor-hq/eksctl-helm-action/issues/1