### PR TITLE
revert: image expressions not supported

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,6 @@ inputs:
   eks_cluster:
     description: "Name of your EKS cluster (i.e., from `eksctl get cluster`)"
     required: true
-  image:
-    description: "Optionally use a pre-built image to save build time"
-    required: false
-    default: "Dockerfile"
   verbose:
     description: "Enables shell command tracing. Takes string input 'true' or 'false'. Defaults to false."
     required: false
@@ -26,6 +22,6 @@ outputs:
     description: "Output returned by your Helm or kubectl command"
 runs:
   using: "docker"
-  image: ${{ inputs.image }}
+  image: "Dockerfile"
   args:
     - ${{ inputs.command }}


### PR DESCRIPTION
seems like expressions are not supported in the `image` parameter and therefore this will not work.
https://github.com/orgs/community/discussions/26382

will need to revisit a solution for this
related to https://github.com/tensor-hq/eksctl-helm-action/issues/4